### PR TITLE
chore(.github/workflows): add stale action for workflows

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+name: Close stale issues and PRs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        id: stale
+        with:
+          delete-branch: true
+          days-before-close: 7
+          days-before-stale: 40
+          days-before-pr-close: 7
+          days-before-pr-stale: 40
+          stale-issue-label: "stale"
+          exempt-issue-labels: bug,wip,on-hold
+          exempt-pr-labels: bug,wip,on-hold
+          exempt-all-milestones: true
+          stale-issue-message: 'This issue is stale because it has been open 40 days with no activity.'
+          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
+          stale-pr-message: 'This PR is stale because it has been open 40 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the management of stale issues and pull requests in the repository. The workflow is designed to mark issues and PRs as stale after a period of inactivity and close them if they remain inactive.

### Workflow automation for stale issues and PRs:

* [`.github/workflows/stale.yml`](diffhunk://#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894R1-R31): Added a new workflow named "Close stale issues and PRs" that runs daily and can also be triggered manually. It uses the `actions/stale` action to mark issues and PRs as stale after 40 days of inactivity and close them after an additional 7 days. The workflow includes configurable messages and exemptions for certain labels and milestones.