### PR TITLE
drop the raw media type from anything other than model(weight)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -42,7 +42,7 @@ The image manifest of model artifacts follows the [OCI Image Manifest Specificat
 
     Implementations SHOULD support the following media types:
 
-    - `application/vnd.cnai.model.weight.v1.raw`: The layer is an unarchived, uncompressed model weights file.
+    - `application/vnd.cnai.model.weight.v1`: The layer is an unarchived, uncompressed model weights file.
 
     - `application/vnd.cnai.model.weight.v1.tar`: The layer is a [tar archive][tar-archive] that contains the model weight file. If the model has multiple weight files, they SHOULD be packaged into separate layers.
 
@@ -50,15 +50,11 @@ The image manifest of model artifacts follows the [OCI Image Manifest Specificat
 
     - `application/vnd.cnai.model.weight.v1.tar+zstd`: The layer is a [tar archive][tar-archive] that includes the configuration file for the model weights. The archive is compressed with [zstd][rfc8478].
 
-    - `application/vnd.cnai.model.weight.config.v1.raw`: The layer is a [tar archive][tar-archive] that includes config of the model weights like tokenizer.json, config.json, etc.
-
     - `application/vnd.cnai.model.weight.config.v1.tar`: The layer is a [tar archive][tar-archive] that includes config of the model weights like tokenizer.json, config.json, etc.
 
     - `application/vnd.cnai.model.weight.config.v1.tar+gzip`: The layer is a [tar archive][tar-archive] that includes config of the model weights like tokenizer.json, config.json, etc. The archive is compressed with [gzip][rfc1952_2].
 
     - `application/vnd.cnai.model.weight.config.v1.tar+zstd`: The layer is a [tar archive][tar-archive] that includes config of the model weights like tokenizer.json, config.json, etc. The archive is compressed with [zstd][rfc8478].
-
-    - `application/vnd.cnai.model.doc.v1.raw`: The layer is an unarchived, uncompressed documentation file.
 
     - `application/vnd.cnai.model.doc.v1.tar`: The layer is a [tar archive][tar-archive] that includes documentation files like `README.md`, `LICENSE`, etc.
 
@@ -66,15 +62,11 @@ The image manifest of model artifacts follows the [OCI Image Manifest Specificat
 
     - `application/vnd.cnai.model.doc.v1.tar+zstd`: The layer is a [tar archive][tar-archive] that includes documentation files like `README.md`, `LICENSE`, etc. The archive is compressed with [zstd][rfc8478].
 
-    - `application/vnd.cnai.model.code.v1.raw`: The layer is an unarchived, uncompressed code artifact.
-
     - `application/vnd.cnai.model.code.v1.tar`: The layer is a [tar archive][tar-archive] that includes code artifacts like scripts, code files etc.
 
     - `application/vnd.cnai.model.code.v1.tar+gzip`: The layer is a [tar archive][tar-archive] that includes code artifacts like scripts, code files etc. The archive is compressed with [gzip][rfc1952_2].
 
     - `application/vnd.cnai.model.code.v1.tar+zstd`: The layer is a [tar archive][tar-archive] that includes code artifacts like scripts, code files etc. The archive is compressed with [zstd][rfc8478].
-
-    - `application/vnd.cnai.model.dataset.v1.raw`: The layer is an unarchived, uncompressed dataset.
 
     - `application/vnd.cnai.model.dataset.v1.tar`: The layer is a [tar archive][tar-archive] that includes datasets that may be needed for the lifecycle of AI/ML models.
 

--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -26,7 +26,7 @@ const (
 	MediaTypeModelConfig = "application/vnd.cnai.model.config.v1+json"
 
 	// MediaTypeModelWeightRaw is the media type used for an unarchived, uncompressed model weights.
-	MediaTypeModelWeightRaw = "application/vnd.cnai.model.weight.v1.raw"
+	MediaTypeModelWeightRaw = "application/vnd.cnai.model.weight.v1"
 
 	// MediaTypeModelWeight is the media type used for model weights.
 	MediaTypeModelWeight = "application/vnd.cnai.model.weight.v1.tar"
@@ -37,9 +37,6 @@ const (
 	// MediaTypeModelWeightZstd is the media type used for zstd compressed model weights.
 	MediaTypeModelWeightZstd = "application/vnd.cnai.model.weight.v1.tar+zstd"
 
-	// MediaTypeModelWeightConfigRaw is the media type used for an unarchived, uncompressed model weights, including files like `tokenizer.json`, `config.json`, etc.
-	MediaTypeModelWeightConfigRaw = "application/vnd.cnai.model.weight.config.v1.raw"
-
 	// MediaTypeModelConfig specifies the media type for configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
 	MediaTypeModelWeightConfig = "application/vnd.cnai.model.weight.config.v1.tar"
 
@@ -48,9 +45,6 @@ const (
 
 	// MediaTypeModelConfigZstd specifies the media type for zstd compressed configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
 	MediaTypeModelWeightConfigZstd = "application/vnd.cnai.model.weight.config.v1.tar+zstd"
-
-	// MediaTypeModelDocRaw is the media type used for an unarchived, uncompressed model documentation, including documentation files like `README.md`, `LICENSE`, etc.
-	MediaTypeModelDocRaw = "application/vnd.cnai.model.doc.v1.raw"
 
 	// MediaTypeModelDoc specifies the media type for model documentation, including documentation files like `README.md`, `LICENSE`, etc.
 	MediaTypeModelDoc = "application/vnd.cnai.model.doc.v1.tar"
@@ -61,9 +55,6 @@ const (
 	// MediaTypeModelDocZstd specifies the media type for zstd compressed model documentation, including documentation files like `README.md`, `LICENSE`, etc.
 	MediaTypeModelDocZstd = "application/vnd.cnai.model.doc.v1.tar+zstd"
 
-	// MediaTypeModelCodeRaw is the media type used for an unarchived, uncompressed model code, including code artifacts like scripts, code files etc.
-	MediaTypeModelCodeRaw = "application/vnd.cnai.model.code.v1.raw"
-
 	// MediaTypeModelCode specifies the media type for model code, including code artifacts like scripts, code files etc.
 	MediaTypeModelCode = "application/vnd.cnai.model.code.v1.tar"
 
@@ -72,9 +63,6 @@ const (
 
 	// MediaTypeModelCodeZstd specifies the media type for zstd compressed model code, including code artifacts like scripts, code files etc.
 	MediaTypeModelCodeZstd = "application/vnd.cnai.model.code.v1.tar+zstd"
-
-	// MediaTypeModelDatasetRaw is the media type used for an unarchived, uncompressed model datasets, including datasets that may be needed throughout the lifecycle of AI/ML models.
-	MediaTypeModelDatasetRaw = "application/vnd.cnai.model.dataset.v1.raw"
 
 	// MediaTypeModelDataset specifies the media type for model datasets, including datasets that may be needed throughout the lifecycle of AI/ML models.
 	MediaTypeModelDataset = "application/vnd.cnai.model.dataset.v1.tar"


### PR DESCRIPTION
question here is: Do we need to also remove the `Raw` suffix from `MediaTypeModelWeightRaw`? If so, we have to also rename the existing `MediaTypeModelWeight` to something like `MediaTypeModelWeightTar` ?