### PR TITLE
chore: add pr-labels actions

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,20 @@
+name: PR Label
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  classify:
+    name: Classify PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR impact specified
+        uses: mheap/github-action-required-labels@8afbe8ae6ab7647d0c9f0cfa7c2f939650d22509 # v5.5
+        with:
+          mode: exactly
+          count: 1
+          labels: 'bug, enhancement, documentation, dependencies'


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate labeling for pull requests. The workflow ensures that each pull request has exactly one label from a predefined set of options.

Workflow addition:

* [`.github/workflows/pr-labels.yml`](diffhunk://#diff-cc6cdcc79d6a4cb86fb60d52a99f98fa1241bf2da9b359dd211e4f67d72edd19R1-R20): Introduced a new workflow named "PR Label" that triggers on pull request events (`opened`, `labeled`, `unlabeled`, `synchronize`) and uses the `mheap/github-action-required-labels` action to enforce one label from the following list: `bug`, `enhancement`, `documentation`, `dependencies`.