### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,24 @@
+---
+name: Bug Report
+about: Report a bug for model spec
+labels: bug
+---
+
+### Bug report:
+
+<!-- Please describe what is actually happening -->
+
+### Expected behavior:
+
+<!-- Please describe what you expect to happen -->
+
+### How to reproduce it:
+
+<!-- How can a maintainer reproduce this issue (please be detailed) -->
+
+### Environment:
+
+- Model Spec version:
+- OS:
+- Kernel (e.g. `uname -a`):
+- Others:

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,4 @@
+---
+name: Custom issue template
+about: Custom issue template for model spec
+---

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,13 @@
+---
+name: Feature Request
+about: Request a new feature for model spec
+labels: enhancement
+---
+
+### Feature request:
+
+<!-- Please describe the feature request and why you would like to have it -->
+
+### Use case:
+
+<!-- Please add a concrete use case to demonstrate how such a feature would add value for the user. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+
+<!--- Describe your changes in detail -->
+
+## Related Issue
+
+<!--- This project only accepts pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please link to the issue here: -->
+
+## Motivation and Context
+
+<!--- Why is this change required? What problem does it solve? -->


### PR DESCRIPTION
This pull request adds standardized issue templates to the repository to streamline bug reporting, feature requests, and custom issues. These templates aim to improve the clarity and consistency of issues submitted by contributors.

New issue templates:

* [`.github/ISSUE_TEMPLATE/bug-report.md`](diffhunk://#diff-5870a741e2fa8d0b03a88d7b036d408ee7e6954051fcc5d7978269bf6d1ff242R1-R24): Added a bug report template with sections for describing the issue, expected behavior, reproduction steps, and environment details.
* [`.github/ISSUE_TEMPLATE/feature-request.md`](diffhunk://#diff-e9349fad824a042e877a9a2f15d475a1fb691346b70711c916e495542e2e6e5eR1-R13): Added a feature request template with sections for describing the feature, its use case, and its potential value.
* [`.github/ISSUE_TEMPLATE/custom.md`](diffhunk://#diff-f1eb04be0397b71ff6eeb0c98d6e03c45d4798093f9592e23bf46f5abe550eb1R1-R4): Added a generic custom issue template for contributors to use when other templates are not applicable.