### PR TITLE
chore: add CODEOWNERS for .github

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# A CODEOWNERS file uses a pattern that follows the same rules used in gitignore files.
+# The pattern is followed by one or more GitHub usernames or team names using the
+# standard @username or @org/team-name format. You can also refer to a user by an
+# email address that has been added to their GitHub account, for example user@example.com
+
+*                                          @modelpack/modelpack-reviewers
+.github                                    @modelpack/modelpack-maintainers


### PR DESCRIPTION
This pull request includes a change to the `.github/CODEOWNERS` file. It adds ownership rules for the repository, assigning all files to the `@modelpack/modelpack-reviewers` team and files in the `.github` directory to the `@modelpack/modelpack-maintainers` team.