### PR TITLE
chore: add dependabot for deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
This pull request introduces a new Dependabot configuration file to automate dependency updates for Go modules and GitHub Actions workflows. The configuration specifies a weekly update schedule for both ecosystems.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R10): Added a new Dependabot configuration file to enable weekly updates for `gomod` (Go modules) and `github-actions` (GitHub Actions workflows).