### PR TITLE
core: change Annotation prefix

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -6,11 +6,11 @@ This property contains arbitrary metadata, and SHOULD follow the rules of [OCI i
 
 ### Layer Annotation Keys
 
-- **`org.cnai.model.filepath`**: Specifies the file path of the layer (string).
+- **`org.cncf.model.filepath`**: Specifies the file path of the layer (string).
 
-- **`org.cnai.model.file.metadata+json`**: Specifies the metadata of the file (string), value is the JSON string of [File Metadata Annotation Value](#File-Metadata-Annotation-Value).
+- **`org.cncf.model.file.metadata+json`**: Specifies the metadata of the file (string), value is the JSON string of [File Metadata Annotation Value](#File-Metadata-Annotation-Value).
 
-- **`org.cnai.model.file.mediatype.untested`**: Indicates whether the media type classification of files in the layer is untested (string). Valid values are `"true"` or `"false"`. When set to `"true"`, it signals that the model packager has not verified the media type classification and the type is inferred or assumed based on some heuristics.
+- **`org.cncf.model.file.mediatype.untested`**: Indicates whether the media type classification of files in the layer is untested (string). Valid values are `"true"` or `"false"`. When set to `"true"`, it signals that the model packager has not verified the media type classification and the type is inferred or assumed based on some heuristics.
 
 ### Layer Annotation Values
 

--- a/specs-go/v1/annotations.go
+++ b/specs-go/v1/annotations.go
@@ -20,13 +20,13 @@ import "time"
 
 const (
 	// AnnotationFilepath is the annotation key for the file path of the layer.
-	AnnotationFilepath = "org.cnai.model.filepath"
+	AnnotationFilepath = "org.cncf.model.filepath"
 
 	// AnnotationFileMetadata is the annotation key for the file metadata of the layer.
-	AnnotationFileMetadata = "org.cnai.model.file.metadata+json"
+	AnnotationFileMetadata = "org.cncf.model.file.metadata+json"
 
 	// AnnotationUntested is the annotation key for file media type untested flag of the layer.
-	AnnotationMediaTypeUntested = "org.cnai.model.file.mediatype.untested"
+	AnnotationMediaTypeUntested = "org.cncf.model.file.mediatype.untested"
 )
 
 // FileMetadata represents the metadata of file, which is the value definition of AnnotationFileMetadata.


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

followup to https://github.com/modelpack/model-spec/pull/81,
since we moved there from mediatype prefix from `vnd.cnai.*` to `vnd.cncf.*`
it seems to me we should do likewise for the Annotations;

wdyt?

## Related Issue

see followup to https://github.com/modelpack/model-spec/pull/81

## Motivation and Context

see followup to https://github.com/modelpack/model-spec/pull/81
