### PR TITLE
[WIP] test: force validating unkown fields in config example

### DIFF
--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -42,8 +42,7 @@
           "capabilities": {
             "$ref": "#/$defs/ModelCapabilities"
           }
-        },
-        "additionalProperties": false
+        }
       },
       "ModelDescriptor": {
         "type": "object",
@@ -92,8 +91,7 @@
           "description": {
             "type": "string"
           }
-        },
-        "additionalProperties": false
+        }
       },
       "ModelFS": {
         "type": "object",
@@ -110,7 +108,6 @@
             "minItems": 1
           }
         },
-        "additionalProperties": false,
         "required": [
           "type",
           "diffIds"

--- a/schema/example_test.go
+++ b/schema/example_test.go
@@ -61,7 +61,7 @@ func validate(t *testing.T, name string) {
 			continue
 		}
 
-		err = schema.Validator(example.Mediatype).Validate(strings.NewReader(example.Body))
+		err = schema.Validator(example.Mediatype).ValidateNoUnknownFields(strings.NewReader(example.Body))
 		if err == nil {
 			printFields(t, "ok", example.Mediatype, example.Title)
 		} else {

--- a/schema/validator.go
+++ b/schema/validator.go
@@ -26,33 +26,55 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v5"
 )
 
-// Validator wraps a media type string identifier and implements validation against a JSON schema.
+// Validate validates the given reader against the schema of the wrapped media type.
+// By default, unknown fields are allowed unless `additionalProperties` is explicitly set to `false`
+// correspondingly in the json schema.
 type Validator string
 
-// Validate validates the given reader against the schema of the wrapped media type.
-func (v Validator) Validate(src io.Reader) error {
+func (v Validator) validateByMediaType(src io.Reader) (io.Reader, error) {
 	// run the media type specific validation
 	if fn, ok := validateByMediaType[v]; ok {
 		if fn == nil {
-			return fmt.Errorf("internal error: mapValidate is nil for %s", string(v))
+			return nil, fmt.Errorf("internal error: mapValidate is nil for %s", string(v))
 		}
 		// buffer the src so the media type validation and the schema validation can both read it
 		buf, err := io.ReadAll(src)
 		if err != nil {
-			return fmt.Errorf("failed to read input: %w", err)
+			return nil, fmt.Errorf("failed to read input: %w", err)
 		}
 		src = bytes.NewReader(buf)
 		err = fn(buf)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	// json schema validation
-	return v.validateSchema(src)
+	return src, nil
 }
 
-func (v Validator) validateSchema(src io.Reader) error {
+// Validate validates the given reader against the schema of the wrapped media type.
+func (v Validator) Validate(src io.Reader) error {
+	srcReader, err := v.validateByMediaType(src)
+	if err != nil {
+		return err
+	}
+
+	// json schema validation
+	return v.validateSchema(srcReader, false)
+}
+
+// ValidateNoUnknownFields validates the given reader against the schema of the wrapped media type and
+// rejects if there are any unknown fields.
+func (v Validator) ValidateNoUnknownFields(src io.Reader) error {
+	srcReader, err := v.validateByMediaType(src)
+	if err != nil {
+		return err
+	}
+
+	return v.validateSchema(srcReader, true)
+}
+
+func (v Validator) validateSchema(src io.Reader, rejectUnknownfields bool) error {
 	if _, ok := specs[v]; !ok {
 		return fmt.Errorf("no validator available for %s", string(v))
 	}
@@ -94,6 +116,10 @@ func (v Validator) validateSchema(src io.Reader) error {
 		return fmt.Errorf("failed to compile schema %s: %w", string(v), err)
 	}
 
+	if rejectUnknownfields {
+		forceSetAdditionalPropertiesFalse(schema)
+	}
+
 	// read in the user input and validate
 	var input interface{}
 	err = json.NewDecoder(src).Decode(&input)
@@ -122,4 +148,39 @@ func validateConfig(buf []byte) error {
 	}
 
 	return nil
+}
+
+// forceSetAdditionalPropertiesFalse recursively traverses the given JSON schema
+// and sets the `AdditionalProperties` field to `false` for all schema objects
+// encountered. This ensures that validation will reject any properties not explicitly
+// defined in the schema.
+//
+// This function modifies the schema in place.
+func forceSetAdditionalPropertiesFalse(schema *jsonschema.Schema) {
+	if len(schema.Types) == 0 {
+		return
+	}
+
+	// We don't have any cases where multiple types are defined for a single field.
+	t := schema.Types[0]
+	if t == "object" {
+		schema.AdditionalProperties = false
+	}
+
+	// Recurse into properties
+	if schema.Properties != nil {
+		for _, propSchema := range schema.Properties {
+			forceSetAdditionalPropertiesFalse(propSchema)
+		}
+	}
+
+	// Recurse into items (for arrays)
+	if schema.Items != nil {
+		forceSetAdditionalPropertiesFalse(schema.Items.(*jsonschema.Schema))
+	}
+
+	// Recurse into additionalProperties if it's a schema
+	if s, ok := schema.AdditionalProperties.(*jsonschema.Schema); ok {
+		forceSetAdditionalPropertiesFalse(s)
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR originally aimed to enforce validation of unknown fields in ModelConfig during CI. Specifically, if a new field is added to ModelConfig without corresponding changes in the JSON schema, the CI would fail, prompting the contributor to update the JSON schema accordingly. However, the implementation will bring significant complexity to the code base (I cannot find an easy to acheive this).

As a fallback option, I decided to validate whether the examples in config.md contain any unknown fields relative to the JSON schema. The limitation of this approach is that the CI can only catch misalignments between the example and the json schema. The ideal scenario is that if the contributors update both the ModelConfig struct and the corresponding example, the CI will function correctly (because CI will only check misalignments between the example and the json schema).

<!--- Describe your changes in detail -->

## Related Issue

#91 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
