### PR TITLE
fix(docs): fix JSON in doc and ci/GHA linting

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -215,7 +215,7 @@ Here is an example model artifact configuration JSON document:
       ],
       "knowledgeCutoff": "2024-05-21T00:00:00Z",
       "reasoning": true,
-      "toolUsage": false
+      "toolUsage": false,
       "embedding": false,
       "reward": false
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As #72 has [been merged](https://github.com/modelpack/model-spec/pull/72#event-18582660222), this started to show [broken](https://github.com/modelpack/model-spec/actions/runs/16216825967/job/45788064727) ci/GHA on main. 

This resolves ci/GHA linting and the Documentation for valid JSON.

## Related Issue

n/a

## Motivation and Context

see above
