### PR TITLE
maintainers: add imeoer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,3 +13,4 @@ The current Maintainers for the project are
 - sabre1041
 - tarilabs
 - wy65701436
+- imeoer


### PR DESCRIPTION
@imeoer contributed the [model-csi-driver](https://github.com/modelpack/model-csi-driver) project to the modelpack community, allowing users to more easily use model spec-based artifacts in Kubernetes. Let's add him as a maintainer.

- [ ] aftersnow
- [x] bergwolf
- [ ] bmicklea
- [x] chlins
- [ ] gaius-qi
- [ ] gorkem
- [ ] raravena80
- [ ] sabre1041
- [ ] tarilabs
- [ ] wy65701436
- [ ] caozhuozi

@aftersnow @bmicklea @chlins @gaius-qi @gorkem @raravena80 @sabre1041 @tarilabs @wy65701436 @caozhuozi please vote!